### PR TITLE
[CI] Add `academy-update` make target  to invoke hugo mod get -u

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ include .github/build/Makefile-show-help.mk
 #----------------------------------------------------------------------------
 # Academy
 # ---------------------------------------------------------------------------
-.PHONY: academy-setup academy-dev academy-staging academy-prod update-module
+.PHONY: academy-setup academy-dev academy-staging academy-prod update-module academy-update
 
 ## Install site dependencies
 academy-setup:
@@ -55,3 +55,7 @@ sync-with-cloud:
 	rm -rf ../meshery-cloud/academy
 	mkdir -p ../meshery-cloud/academy
 	rsync -av --delete public/ ../meshery-cloud/academy/
+
+## Update the academy-theme package to latest version
+academy-update:
+	hugo mod get -u

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,10 @@ module github.com/layer5io/academy
 go 1.12
 
 require (
+	github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 // indirect
+	github.com/google/docsy v0.12.0 // indirect
 	github.com/layer5io/academy-theme v0.1.15 // indirect
 	github.com/layer5io/exoscale-academy v0.3.2 // indirect
-	github.com/layer5io/layer5-academy v0.1.6 // indirect
+	github.com/layer5io/layer5-academy v0.1.7 // indirect
+	github.com/twbs/bootstrap v5.3.7+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 h1:/iluJkJiyTAdnqrw3Yi9rH2HNHhrrtCmj8VJe7I6o3w=
 github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.12.0 h1:CddZKL39YyJzawr8GTVaakvcUTCJRAAYdz7W0qfZ2P4=
 github.com/google/docsy v0.12.0/go.mod h1:1bioDqA493neyFesaTvQ9reV0V2vYy+xUAnlnz7+miM=
 github.com/layer5io/academy-theme v0.1.10/go.mod h1:kAidN16xIX6Dx2TBz7y0u3DeU8UnfUcoQZ/rVogXN80=
 github.com/layer5io/academy-theme v0.1.15 h1:cDIOgNOM8qF6o4HVLnQnhyWBpTaaVvUz+ANJzwcTfLA=
@@ -8,5 +10,8 @@ github.com/layer5io/exoscale-academy v0.3.2/go.mod h1:1S4qs8cy686HvTkvvZt+yhyi3E
 github.com/layer5io/hugo-academy-theme v0.0.0-20250715053027-36f46b5c4741/go.mod h1:Kp2xgJUAqGztDN/j6T30ApwSaK1Yxs1IvrSgOoRFKnI=
 github.com/layer5io/layer5-academy v0.1.6 h1:imcz2Wsjvv0Dl++P5mGeMF1n9AaIP5qdHtxr7x9Imt4=
 github.com/layer5io/layer5-academy v0.1.6/go.mod h1:43Vsb+x/qWod1ukqqHZYVfrvLxbCCBwusMZpzouVs/U=
+github.com/layer5io/layer5-academy v0.1.7 h1:PB0Q0rfYiJNe44Plcn098ELtKH9hO5V4mOWlWUH/+7I=
+github.com/layer5io/layer5-academy v0.1.7/go.mod h1:mxithFlM+rYS6Dfqu95OyCpLN0NJz8Rmg50x8zRzEuw=
 github.com/twbs/bootstrap v5.3.6+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v5.3.7+incompatible h1:ea1W8TOWZFkqSK2M0McpgzLiUQVru3bz8aHb0j/XtuM=
 github.com/twbs/bootstrap v5.3.7+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
**Notes for Reviewers**

tthis PR adds the `academy-update` Make target to invoke `hugo mod get -u`

This is part of addressing [layer5io/exoscale-academy#120](https://github.com/layer5io/exoscale-academy/issues/120)



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [✅] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
