### PR TITLE
[Automated] Update academy-theme to v0.1.28

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/FortAwesome/Font-Awesome v4.7.0+incompatible => github.com/Fo
 
 require (
 	github.com/FortAwesome/Font-Awesome v4.7.0+incompatible // indirect
-	github.com/layer5io/academy-theme v0.1.27 // indirect
+	github.com/layer5io/academy-theme v0.1.28 // indirect
 	github.com/layer5io/exoscale-academy v0.4.10 // indirect
 	github.com/layer5io/layer5-academy v0.2.5 // indirect
 	github.com/twbs/bootstrap v5.3.7+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/layer5io/academy-theme v0.1.26 h1:bRt6Z5jFwZMEovRZDtceyOeUENjaFh0iIzq
 github.com/layer5io/academy-theme v0.1.26/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/academy-theme v0.1.27 h1:vVHBtZMOLJn9CbBG9iIcxxv6+TAmD3d7UusKH0a5KcE=
 github.com/layer5io/academy-theme v0.1.27/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.1.28 h1:PgavFwP+N+HC6hbNnaHQUuB8v7X8553eS20jibnMOn8=
+github.com/layer5io/academy-theme v0.1.28/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/exoscale-academy v0.4.0 h1:yC163yGQrvplEcGjrJmZRz5XHe+EknCkgfHlANuNn7Y=
 github.com/layer5io/exoscale-academy v0.4.0/go.mod h1:mVXp2h/NImCJ5IvVfM8q4fq8qT3Qxc5OMTBhQw4mEZ8=
 github.com/layer5io/exoscale-academy v0.4.1 h1:XA4nwObZPxabYjgxxg4Qk/v9nuhrNcEtcXIvQzHLppY=


### PR DESCRIPTION
This PR updates the academy-theme dependency to the latest release version v0.1.28.

Changes:
- Updated go.mod
- Regenerated go.sum

Auto-generated based upon release of a new version of layer5io/academy-theme.