### PR TITLE
[Automated] Update academy-theme to v0.2.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/FortAwesome/Font-Awesome v4.7.0+incompatible => github.com/Fo
 
 require (
 	github.com/FortAwesome/Font-Awesome v4.7.0+incompatible // indirect
-	github.com/layer5io/academy-theme v0.2.3 // indirect
+	github.com/layer5io/academy-theme v0.2.4 // indirect
 	github.com/layer5io/exoscale-academy v0.5.5 // indirect
 	github.com/layer5io/layer5-academy v0.2.7 // indirect
 	github.com/twbs/bootstrap v5.3.7+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/layer5io/academy-theme v0.2.2 h1:bo5N3cKFeaTgjEm8YCFD1HPPyJZinoFpN1Xh
 github.com/layer5io/academy-theme v0.2.2/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/academy-theme v0.2.3 h1:LSG2J0zndp4rrktw984dgrMu0r9liOHz44pGTbCG8jU=
 github.com/layer5io/academy-theme v0.2.3/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.2.4 h1:h8qNwyiRUKjQVuRZRdIvDKtYld6PyNdZjBJFrz77dpM=
+github.com/layer5io/academy-theme v0.2.4/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/exoscale-academy v0.4.0 h1:yC163yGQrvplEcGjrJmZRz5XHe+EknCkgfHlANuNn7Y=
 github.com/layer5io/exoscale-academy v0.4.0/go.mod h1:mVXp2h/NImCJ5IvVfM8q4fq8qT3Qxc5OMTBhQw4mEZ8=
 github.com/layer5io/exoscale-academy v0.4.1 h1:XA4nwObZPxabYjgxxg4Qk/v9nuhrNcEtcXIvQzHLppY=


### PR DESCRIPTION
This PR updates the academy-theme dependency to the latest release version v0.2.4.

Changes:
- Updated go.mod
- Regenerated go.sum

Auto-generated based upon release of a new version of layer5io/academy-theme.