### PR TITLE
Enhance academy-build Workflow to Support Release-Drafter Integration

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -102,9 +102,9 @@ jobs:
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           path: meshery-cloud
-          commit-message: "Add academy release: ${{ github.event.inputs.notes || 'Updated academy content' }} for v${{ github.event.inputs.version || 'latest' }} [CI]"
-          title: "${{ github.event.inputs.notes || 'Updated academy content' }}"
-          body: "Automated PR for academy release v${{ github.event.inputs.version || 'latest' }} from academy-build. OrgId: ${{ github.event.inputs.orgId || 'manual' }}."
+          commit-message: "Add ${ACADEMY_NAME} release v${{ github.event.inputs.version || 'latest' }}: $NOTES [CI]"
+          title: "${ACADEMY_NAME} v${{ github.event.inputs.version || 'latest' }}: $NOTES"
+          body: "Automated PR for ${ACADEMY_NAME} release v${{ github.event.inputs.version || 'latest' }} from academy-build. OrgId: ${{ github.event.inputs.orgId || 'manual' }}."
           branch: academy-release-v${{ github.event.inputs.version || 'latest' }}
           labels: academy
 


### PR DESCRIPTION
**Notes for Reviewers**

This pull request updates the build-and-release.yml workflow in layer5io/academy-build to ensure academy releases are properly reflected in layer5io/meshery-cloud’s release notes.

The changes introduce a PR-based (a release note PR) approach with manual merging for release-drafter integration.


This PR fixes [#806](https://github.com/layer5io/docs/issues/806)




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
