### PR TITLE
Enhance workflow for release-drafter integration of academy release notes in meshery-cloud

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -103,10 +103,10 @@ jobs:
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           path: meshery-cloud
-          commit-message: "Add Academy release v${{ github.event.inputs.version || 'latest' }} for orgId: ${{ github.event.inputs.orgId || 'manual' }} ${{ github.event.inputs.NOTES || '' }} [CI]"
-          title: "Academy v${{ github.event.inputs.version || 'latest' }} for orgId: ${{ github.event.inputs.orgId || 'manual' }} ${{ github.event.inputs.NOTES || '' }}"
-          body: "Automated PR for Academy release v${{ github.event.inputs.version || 'latest' }} from academy-build. OrgId: ${{ github.event.inputs.orgId || 'manual' }}."
-          branch: academy-release-v${{ github.event.inputs.version || 'latest' }}
+          commit-message: "Add ${{ github.repository.split('/')[1] }} v${{ github.event.inputs.version || 'latest' }} [CI]"
+          title: "${{ github.repository.split('/')[1] }} v${{ github.event.inputs.version || 'latest' }}"
+          body: "Automated PR for ${{ github.repository.split('/')[1] }} release v${{ github.event.inputs.version || 'latest' }} from academy-build. OrgId: ${{ github.event.inputs.orgId || 'manual' }}."
+          branch: ${{ format('{0}-release-v{1}', github.repository.split('/')[1], github.event.inputs.version || 'latest') }}
           labels: academy
 
       - name: Auto-merge PR in meshery-cloud repo


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes skip behavior for creation of PR and auto merge in build & release. removed if clause.



<img width="1182" height="127" alt="Screenshot 2025-09-08 at 21 30 26" src="https://github.com/user-attachments/assets/17b0045c-de46-4d54-8832-53e4ab8635fc" />



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
