### PR TITLE
[Automated] Update academy-theme to v0.3.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/FortAwesome/Font-Awesome v4.7.0+incompatible => github.com/Fo
 
 require (
 	github.com/FortAwesome/Font-Awesome v4.7.0+incompatible // indirect
-	github.com/layer5io/academy-theme v0.3.6 // indirect
+	github.com/layer5io/academy-theme v0.3.7 // indirect
 	github.com/layer5io/digitalocean-academy v0.1.9 // indirect
 	github.com/layer5io/exoscale-academy v0.6.17 // indirect
 	github.com/layer5io/layer5-academy v0.7.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/layer5io/academy-theme v0.3.5 h1:6LV6puez+NrzEWgbxuvgc2IUfyz1LcQsclt5
 github.com/layer5io/academy-theme v0.3.5/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/academy-theme v0.3.6 h1:td3ruHtuAVEJBmzJixThatBpZsz2isU9hH7palpIUzY=
 github.com/layer5io/academy-theme v0.3.6/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.3.7 h1:i7ar0YZiCLSY85CjOIySaMhNLDLQ2ldTNwqL4Z6UPJE=
+github.com/layer5io/academy-theme v0.3.7/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/digitalocean-academy v0.0.0-20250811164829-9c9fe0d0fb30 h1:uOYEZhHFszNjb0ceanoSk118T+6KAFcTopZGYNSVLeQ=
 github.com/layer5io/digitalocean-academy v0.0.0-20250811164829-9c9fe0d0fb30/go.mod h1:HwJAxS+mg1K33NKaDIngdVhya6+GPAraeTyi6g+4268=
 github.com/layer5io/digitalocean-academy v0.1.1 h1:cYIV8WZGCUHxrEg1NtXtqIhvQuWVbvlGmzl6knsS6So=


### PR DESCRIPTION
This PR updates the academy-theme dependency to the latest release version v0.3.7.

Changes:
- Updated go.mod
- Regenerated go.sum

Auto-generated based upon release of a new version of layer5io/academy-theme.