### PR TITLE
[Automated] Update academy-theme to v0.4.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/FortAwesome/Font-Awesome v4.7.0+incompatible => github.com/Fo
 
 require (
 	github.com/FortAwesome/Font-Awesome v4.7.0+incompatible // indirect
-	github.com/layer5io/academy-theme v0.4.4 // indirect
+	github.com/layer5io/academy-theme v0.4.5 // indirect
 	github.com/layer5io/digitalocean-academy v0.1.12 // indirect
 	github.com/layer5io/exoscale-academy v0.6.31 // indirect
 	github.com/layer5io/layer5-academy v0.8.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/layer5io/academy-theme v0.4.3 h1:2R6aF6Qfn77BHhsojARLWiqANI4s12dQ6hZ5
 github.com/layer5io/academy-theme v0.4.3/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/academy-theme v0.4.4 h1:BDGDQtmhBvj4cxcwJt4/Q43eF26Urp9CyENrP6KhyXM=
 github.com/layer5io/academy-theme v0.4.4/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.4.5 h1:SfjQ63uYxgtsqdo8qPjvr7/9ygkMQZK80BO+6piWUaQ=
+github.com/layer5io/academy-theme v0.4.5/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/digitalocean-academy v0.0.0-20250811164829-9c9fe0d0fb30 h1:uOYEZhHFszNjb0ceanoSk118T+6KAFcTopZGYNSVLeQ=
 github.com/layer5io/digitalocean-academy v0.0.0-20250811164829-9c9fe0d0fb30/go.mod h1:HwJAxS+mg1K33NKaDIngdVhya6+GPAraeTyi6g+4268=
 github.com/layer5io/digitalocean-academy v0.1.1 h1:cYIV8WZGCUHxrEg1NtXtqIhvQuWVbvlGmzl6knsS6So=


### PR DESCRIPTION
This PR updates the academy-theme dependency to the latest release version v0.4.5.

Changes:
- Updated go.mod
- Regenerated go.sum

Auto-generated based upon release of a new version of layer5io/academy-theme.