### PR TITLE
[Automated] Update academy-theme to v0.4.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/FortAwesome/Font-Awesome v4.7.0+incompatible => github.com/Fo
 
 require (
 	github.com/FortAwesome/Font-Awesome v4.7.0+incompatible // indirect
-	github.com/layer5io/academy-theme v0.4.8 // indirect
+	github.com/layer5io/academy-theme v0.4.9 // indirect
 	github.com/layer5io/digitalocean-academy v0.1.12 // indirect
 	github.com/layer5io/exoscale-academy v0.6.31 // indirect
 	github.com/layer5io/layer5-academy v0.8.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/layer5io/academy-theme v0.4.7 h1:Wq1uaVZN04rXnrMgX2K37M2xr/yR0I6NiyOW
 github.com/layer5io/academy-theme v0.4.7/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/academy-theme v0.4.8 h1:K9BwfxjE5ieBA1/0qXjBHLMskQI6xZcQxmoWIxPtwR8=
 github.com/layer5io/academy-theme v0.4.8/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.4.9 h1:MQi5yZ2HmTzBVDZn+4CUuPRIxAlYCbwCOza4TUQUjtE=
+github.com/layer5io/academy-theme v0.4.9/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/digitalocean-academy v0.0.0-20250811164829-9c9fe0d0fb30 h1:uOYEZhHFszNjb0ceanoSk118T+6KAFcTopZGYNSVLeQ=
 github.com/layer5io/digitalocean-academy v0.0.0-20250811164829-9c9fe0d0fb30/go.mod h1:HwJAxS+mg1K33NKaDIngdVhya6+GPAraeTyi6g+4268=
 github.com/layer5io/digitalocean-academy v0.1.1 h1:cYIV8WZGCUHxrEg1NtXtqIhvQuWVbvlGmzl6knsS6So=


### PR DESCRIPTION
This PR updates the academy-theme dependency to the latest release version v0.4.9.

Changes:
- Updated go.mod
- Regenerated go.sum

Auto-generated based upon release of a new version of layer5io/academy-theme.