### PR TITLE
chore: Standardize Makefile npm scripts

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,0 +1,45 @@
+# htmltest configuration.
+# Checks the built HTML in public/ for broken links, images, and scripts.
+# External links are skipped at runtime via the -s flag in the check:links script.
+
+DirectoryPath: "public"
+
+CheckInternal: true
+CheckExternal: true       # skipped at runtime by -s; left true for when you drop -s
+EnforceHTTPS: true        # still flags real http:// links (e.g. exoscale.com) to fix
+
+# --- Silence intentional or non-blocking findings ---
+
+# Hugo serves pages as directories, so a link to "./foo" (no trailing slash)
+# only causes a redirect, not a break. Don't treat these as errors.
+IgnoreDirectoryMissingTrailingSlash: true
+
+# Alt-text issues are an accessibility backlog, not broken links. Empty alt is
+# valid for decorative images. Re-enable (set these false) when you work the
+# accessibility pass.
+IgnoreAltEmpty: true
+IgnoreAltMissing: true
+
+# Deliberate example URLs in workshop content (intentionally http, not real
+# reachable hosts). These skip HTTPS enforcement; genuine http links elsewhere
+# (exoscale.com, etc.) are NOT listed here, so they still surface for fixing.
+IgnoreHTTPS:
+  - '^http://localhost'
+  - 'votingapp\.(com|cc)'
+  - 'nip\.io'
+  - 'thesecretlivesofdata\.com'
+
+# Directories in public/ to skip entirely (adjust per repo as needed).
+# Theme/shortcode demonstration pages full of intentional example links and
+# placeholder image paths. Not real content; skip the whole section.
+IgnoreDirs:
+  - 'content-formatting-examples'
+
+# Cache external-link results for fast repeat runs (stored under tmp/.htmltest;
+# add tmp/ to .gitignore). Harmless under -s.
+CacheExpires: "336h"
+
+
+# Known-noisy or intentionally-unreachable URLs to ignore (regex).
+# IgnoreURLs:
+#   - "^https://linkedin\\.com/"

--- a/Makefile
+++ b/Makefile
@@ -1,60 +1,24 @@
 # Copyright Layer5, Inc.
 #
-# Licensed under the GNU Affero General Public License, Version 3.0
-# (the # "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    https://www.gnu.org/licenses/agpl-3.0.en.html
 #    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
-@@ -13,83 +13,145 @@
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 include .github/build/Makefile.core.mk
 include .github/build/Makefile-show-help.mk
 
-#----------------------------------------------------------------------------
-# Academy
-# ---------------------------------------------------------------------------
-.PHONY: setup build stg-build prod-build theme-update sync-with-cloud site check-go update-module update-org-to-module-version
-
-## ------------------------------------------------------------
-----LOCAL_BUILDS: Show help for available targets
-	
-## Local: Install site dependencies
-setup:
-	 npm i
-
-## Local: Build site for local consumption
-build:
-	hugo build
-
-## Local: Build site for local consumption remove files from destination not found in static directories
-build-clean:
-	hugo build --cleanDestinationDir
-
-## Local: Build and run site locally with draft and future content enabled.
-site: check-go
-	hugo server -D -F
-
-## ------------------------------------------------------------
-----REMOTE_BUILDS: Show help for available targets
 # Changes to any STANDARD recipe below require a corresponding change in all other
 # repositories subscribed to the 'meshery-academy' topic. Recipes under the
 # "REPO-SPECIFIC" section exist only in this repo and must NOT be propagated.
 
-## Build site using Layer5 Cloud Staging as the baseURL
-stg-build:
-	 hugo --cleanDestinationDir --gc --minify --baseURL "https://staging-cloud.layer5.io/academy"
-
-## Build site using Layer5 Cloud as the baseURL
-prod-build:
-	 hugo  --cleanDestinationDir --gc --minify --baseURL "https://cloud.layer5.io/academy"
 # htmltest is fetched and run on demand via 'go run' (no install step). Pin it for
 # reproducible link checks; leave as 'latest' to always use the newest release.
 HTMLTEST_VERSION ?= latest
@@ -64,8 +28,6 @@ export HTMLTEST_VERSION
 # MAINTENANCE (standard)
 # ---------------------------------------------------------------------------
 
-## ------------------------------------------------------------
-----MAINTENANCE: Show help for available targets
 ## Verify required commands and local dependencies are present.
 check-deps:
 	@echo "Checking if 'npm' and local 'hugo' binary are present..."
@@ -75,15 +37,11 @@ check-deps:
 
 ## Validate Go is installed
 check-go:
-@echo "Checking if Go is installed..."
-	@command -v go > /dev/null || (echo "Go is not installed. Please install it before proceeding."; exit 1)
+	@echo "Checking if Go is installed..."
 	@command -v go > /dev/null || { echo "Go is not installed. Please install it before proceeding."; exit 1; }
-@echo "Go is installed."
+	@echo "Go is installed."
 
 ## Update the academy-theme package to latest version
-theme-update:
-	echo "Updating to latest academy-theme..." && \
-	hugo mod get github.com/layer5io/academy-theme
 theme-update: check-go check-deps
 	@echo "Updating to latest academy-theme..."
 	npm run update:theme
@@ -92,8 +50,6 @@ theme-update: check-go check-deps
 # LOCAL BUILDS (standard)
 # ---------------------------------------------------------------------------
 
-## Update a specific Hugo module to a specific version.
-update-module:
 ## Install site dependencies
 setup:
 	npm install
@@ -153,39 +109,32 @@ build-staging: check-go check-deps
 	npm run build:production -- --baseURL "https://staging-cloud.layer5.io/academy"
 
 ## [repo-specific] Update a specific Hugo module to a specific version.
-update-module: check-go
-@if [ -z "$(module)" ] || [ -z "$(version)" ]; then \
-echo "Usage: make update-module module=<module-path> version=<version>"; \
-exit 1; \
-fi && \
-echo "Updating Hugo module: $(module) to version $(version)" && \
-hugo mod get $(module)@$(version)
+update-module: check-go check-deps
+	@if [ -z "$(module)" ] || [ -z "$(version)" ]; then \
+		echo "Usage: make update-module module=<module-path> version=<version>"; \
+		exit 1; \
+	fi && \
+	echo "Updating Hugo module: $(module) to version $(version)" && \
+	npm run update:module -- $(module)@$(version)
 
 ## [repo-specific] Set an org's module version in academy_config.json.
 update-org-to-module-version:
-@if [ -z "$(orgId)" ] || [ -z "$(version)" ]; then \
-		echo "Usage: make update-org-to-module-mapping orgId=<org-id> version=<version>"; \
+	@if [ -z "$(orgId)" ] || [ -z "$(version)" ]; then \
 		echo "Usage: make update-org-to-module-version orgId=<org-id> version=<version>"; \
-exit 1; \
-fi && \
+		exit 1; \
+	fi && \
 	echo "Setting org $(orgId) to module version $(version)" && \
-jq --arg orgId "$(orgId)" --arg version "$(version)" \
-'.orgToModuleMapping[$$orgId].version = $$version' \
-academy_config.json > tmp.json && mv tmp.json academy_config.json
+	jq --arg orgId "$(orgId)" --arg version "$(version)" \
+	'.orgToModuleMapping[$$orgId].version = $$version' \
+	academy_config.json > tmp.json && mv tmp.json academy_config.json
 
-
-## Publish Academy build to Layer5 Cloud.
-## Copy built site from public/ to 
-## ../meshery-cloud/academy directory
 ## [repo-specific] Publish the built site to the Layer5 Cloud (../meshery-cloud/academy).
 sync-with-cloud:
 	@test -d ../meshery-cloud || { echo "Error: ../meshery-cloud sibling checkout not found."; exit 1; }
-rm -rf ../meshery-cloud/academy
-mkdir -p ../meshery-cloud/academy
-	rsync -av --delete public/ ../meshery-cloud/academy/ 
+	rm -rf ../meshery-cloud/academy
+	mkdir -p ../meshery-cloud/academy
 	rsync -av --delete public/ ../meshery-cloud/academy/
-cp academy_config.json ../meshery-cloud/academy/
-	@echo "Academy site synced with Layer5 Cloud." 
+	cp academy_config.json ../meshery-cloud/academy/
 	@echo "Academy site synced with Layer5 Cloud."
 
 .PHONY: \

--- a/Makefile
+++ b/Makefile
@@ -3,25 +3,69 @@
 # Licensed under the GNU Affero General Public License, Version 3.0
 # (the # "License"); you may not use this file except in compliance
 # with the License. You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
 #    https://www.gnu.org/licenses/agpl-3.0.en.html
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
+@@ -13,83 +13,145 @@
 # limitations under the License.
 
 include .github/build/Makefile.core.mk
 include .github/build/Makefile-show-help.mk
 
-# ---------------------------------------------------------------------------
+#----------------------------------------------------------------------------
 # Academy
+# ---------------------------------------------------------------------------
+.PHONY: setup build stg-build prod-build theme-update sync-with-cloud site check-go update-module update-org-to-module-version
+
+## ------------------------------------------------------------
+----LOCAL_BUILDS: Show help for available targets
+	
+## Local: Install site dependencies
+setup:
+	 npm i
+
+## Local: Build site for local consumption
+build:
+	hugo build
+
+## Local: Build site for local consumption remove files from destination not found in static directories
+build-clean:
+	hugo build --cleanDestinationDir
+
+## Local: Build and run site locally with draft and future content enabled.
+site: check-go
+	hugo server -D -F
+
+## ------------------------------------------------------------
+----REMOTE_BUILDS: Show help for available targets
+# Changes to any STANDARD recipe below require a corresponding change in all other
+# repositories subscribed to the 'meshery-academy' topic. Recipes under the
+# "REPO-SPECIFIC" section exist only in this repo and must NOT be propagated.
+
+## Build site using Layer5 Cloud Staging as the baseURL
+stg-build:
+	 hugo --cleanDestinationDir --gc --minify --baseURL "https://staging-cloud.layer5.io/academy"
+
+## Build site using Layer5 Cloud as the baseURL
+prod-build:
+	 hugo  --cleanDestinationDir --gc --minify --baseURL "https://cloud.layer5.io/academy"
+# htmltest is fetched and run on demand via 'go run' (no install step). Pin it for
+# reproducible link checks; leave as 'latest' to always use the newest release.
+HTMLTEST_VERSION ?= latest
+export HTMLTEST_VERSION
+
+# ---------------------------------------------------------------------------
+# MAINTENANCE (standard)
 # ---------------------------------------------------------------------------
 
 ## ------------------------------------------------------------
 ----MAINTENANCE: Show help for available targets
-
 ## Verify required commands and local dependencies are present.
 check-deps:
 	@echo "Checking if 'npm' and local 'hugo' binary are present..."
@@ -31,103 +75,135 @@ check-deps:
 
 ## Validate Go is installed
 check-go:
-	@echo "Checking if Go is installed..."
+@echo "Checking if Go is installed..."
+	@command -v go > /dev/null || (echo "Go is not installed. Please install it before proceeding."; exit 1)
 	@command -v go > /dev/null || { echo "Go is not installed. Please install it before proceeding."; exit 1; }
-	@echo "Go is installed."
+@echo "Go is installed."
 
 ## Update the academy-theme package to latest version
+theme-update:
+	echo "Updating to latest academy-theme..." && \
+	hugo mod get github.com/layer5io/academy-theme
 theme-update: check-go check-deps
 	@echo "Updating to latest academy-theme..."
 	npm run update:theme
 
+# ---------------------------------------------------------------------------
+# LOCAL BUILDS (standard)
+# ---------------------------------------------------------------------------
+
 ## Update a specific Hugo module to a specific version.
-update-module: check-go check-deps
-	@if [ -z "$(module)" ] || [ -z "$(version)" ]; then \
-		echo "Usage: make update-module module=<module-path> version=<version>"; \
-		exit 1; \
-	fi && \
-	echo "Updating Hugo module: $(module) to version $(version)" && \
-	hugo mod get $(module)@$(version)
-
-update-org-to-module-version:
-	@if [ -z "$(orgId)" ] || [ -z "$(version)" ]; then \
-		echo "Usage: make update-org-to-module-mapping orgId=<org-id> version=<version>"; \
-		exit 1; \
-	fi && \
-	jq --arg orgId "$(orgId)" --arg version "$(version)" \
-	'.orgToModuleMapping[$$orgId].version = $$version' \
-	academy_config.json > tmp.json && mv tmp.json academy_config.json
-
-## ------------------------------------------------------------
-----LOCAL_BUILDS: Show help for available targets
-
+update-module:
 ## Install site dependencies
 setup:
 	npm install
 
-## Build site for local consumption
+## Build the site locally with draft and future content enabled.
 build: check-go check-deps
-	npm run build:production
+	npm run build
 
-## Build site for local consumption
+## Build the site for a deploy preview.
 build-preview: check-go check-deps
 	npm run build:preview
 
-## Build and run site locally with draft and future content enabled.
+## Build site using Layer5 Cloud as the baseURL.
+build-production: check-go check-deps
+	npm run build:production -- --baseURL "https://cloud.layer5.io/academy"
+
+## Build and run the site locally with live reload (draft and future content enabled).
 site: check-go check-deps
 	npm run site
 
-## Build and run site locally
-serve: check-go check-deps
-	npm run serve
+## Build and serve the site once with the file-watcher off (no live reload).
+site-no-watch: check-go check-deps
+	npm run site:no-watch
 
-## Empty build cache and run on your local machine.
+## Empty the build cache, reinstall dependencies, and run the site locally.
 clean:
 	npm run clean
+	$(MAKE) setup
+	$(MAKE) site
+
+## Check internal links in the built site (htmltest is fetched on demand via 'go run').
+check-links: check-go check-deps
+	npm run check:links
 
 ## Format code using Prettier
 format:
 	npm run format
 
+## Check formatting without writing changes.
+format-check:
+	npm run format:check
+
 ## Fix Markdown linting issues
 lint-fix:
-	npm run lint:fix
+	npx --yes markdownlint-cli2 --fix "content/**/*.md"
 
-## ------------------------------------------------------------
-----REMOTE_BUILDS: Show help for available targets
+# ===========================================================================
+# REPO-SPECIFIC RECIPES
+# NOT part of the shared 'meshery-academy' standard. These depend on Layer5
+# Cloud infrastructure (academy_config.json, the ../meshery-cloud sibling, a
+# staging URL) and exist only in this repository. Do NOT propagate them to the
+# other academy repos.
+# ===========================================================================
 
-## Build site using Layer5 Cloud Staging as the baseURL
-stg-build: check-go check-deps
-	npm run _hugo -- --gc --minify --baseURL "https://staging-cloud.layer5.io/academy"
+## [repo-specific] Build the site using the Layer5 Cloud Staging baseURL.
+build-staging: check-go check-deps
+	npm run build:production -- --baseURL "https://staging-cloud.layer5.io/academy"
 
-## Build site using Layer5 Cloud as the baseURL
-prod-build: check-go check-deps
-	npm run _hugo -- --gc --minify --baseURL "https://cloud.layer5.io/academy"
+## [repo-specific] Update a specific Hugo module to a specific version.
+update-module: check-go
+@if [ -z "$(module)" ] || [ -z "$(version)" ]; then \
+echo "Usage: make update-module module=<module-path> version=<version>"; \
+exit 1; \
+fi && \
+echo "Updating Hugo module: $(module) to version $(version)" && \
+hugo mod get $(module)@$(version)
+
+## [repo-specific] Set an org's module version in academy_config.json.
+update-org-to-module-version:
+@if [ -z "$(orgId)" ] || [ -z "$(version)" ]; then \
+		echo "Usage: make update-org-to-module-mapping orgId=<org-id> version=<version>"; \
+		echo "Usage: make update-org-to-module-version orgId=<org-id> version=<version>"; \
+exit 1; \
+fi && \
+	echo "Setting org $(orgId) to module version $(version)" && \
+jq --arg orgId "$(orgId)" --arg version "$(version)" \
+'.orgToModuleMapping[$$orgId].version = $$version' \
+academy_config.json > tmp.json && mv tmp.json academy_config.json
+
 
 ## Publish Academy build to Layer5 Cloud.
 ## Copy built site from public/ to 
 ## ../meshery-cloud/academy directory
+## [repo-specific] Publish the built site to the Layer5 Cloud (../meshery-cloud/academy).
 sync-with-cloud:
-	rm -rf ../meshery-cloud/academy
-	mkdir -p ../meshery-cloud/academy
+	@test -d ../meshery-cloud || { echo "Error: ../meshery-cloud sibling checkout not found."; exit 1; }
+rm -rf ../meshery-cloud/academy
+mkdir -p ../meshery-cloud/academy
 	rsync -av --delete public/ ../meshery-cloud/academy/ 
-	cp academy_config.json ../meshery-cloud/academy/
+	rsync -av --delete public/ ../meshery-cloud/academy/
+cp academy_config.json ../meshery-cloud/academy/
 	@echo "Academy site synced with Layer5 Cloud." 
+	@echo "Academy site synced with Layer5 Cloud."
 
 .PHONY: \
 	setup \
 	build \
 	build-preview \
-	serve \
+	build-production \
 	site \
+	site-no-watch \
 	clean \
+	check-links \
 	format \
+	format-check \
 	lint-fix \
-	stg-build \
-	prod-build \
-	theme-update \
-	sync-with-cloud \
 	check-deps \
 	check-go \
+	theme-update \
+	build-staging \
 	update-module \
-	update-org-to-module-version
+	update-org-to-module-version \
+	sync-with-cloud

--- a/Makefile
+++ b/Makefile
@@ -15,83 +15,33 @@
 include .github/build/Makefile.core.mk
 include .github/build/Makefile-show-help.mk
 
-#----------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Academy
 # ---------------------------------------------------------------------------
-## ------------------------------------------------------------
-----LOCAL_BUILDS: Show help for available targets
-	
-## Local: Install site dependencies
-setup: check-deps
-	npm install
-
-## Local: Build and run site locally with draft and future content enabled.
-site: check-go
-	hugo server -D -F
-
-## Local: Build site for local consumption
-build:
-	hugo build
-
-## Build site for local consumption
-build-preview:
-	hugo --baseURL=$(BASEURL)
-
-## Empty build cache and run on your local machine.
-clean:
-	hugo --cleanDestinationDir
-	make setup
-	make site
-
-## Local: Build site for local consumption remove files from destination not found in static directories
-build-clean:
-	hugo build --cleanDestinationDir
-
-## ------------------------------------------------------------
-----REMOTE_BUILDS: Show help for available targets
-
-## Build site using Layer5 Cloud Staging as the baseURL
-stg-build:
-	hugo --cleanDestinationDir --gc --minify --baseURL "https://staging-cloud.layer5.io/academy"
-
-## Build site using Layer5 Cloud as the baseURL
-prod-build:
-	hugo  --cleanDestinationDir --gc --minify --baseURL "https://cloud.layer5.io/academy"
-
 
 ## ------------------------------------------------------------
 ----MAINTENANCE: Show help for available targets
 
+## Verify required commands and local dependencies are present.
+check-deps:
+	@echo "Checking if 'npm' and local 'hugo' binary are present..."
+	@command -v npm > /dev/null || { echo "Error: 'npm' not found. Please install Node.js and npm."; exit 1; }
+	@test -x node_modules/.bin/hugo || { echo "Error: Hugo binary not found in node_modules. Please run 'make setup' first."; exit 1; }
+	@echo "Dependencies check passed."
+
+## Validate Go is installed
 check-go:
 	@echo "Checking if Go is installed..."
-	@command -v go > /dev/null || (echo "Go is not installed. Please install it before proceeding."; exit 1)
+	@command -v go > /dev/null || { echo "Go is not installed. Please install it before proceeding."; exit 1; }
 	@echo "Go is installed."
 
-## Check for required dependencies (Node.js and npm) and versions
-check-deps:
-	@echo "Checking for required dependencies..."
-	@command -v node > /dev/null || (echo "Node.js is not installed. Please install Node.js v14+ before proceeding."; exit 1)
-	@NODE_VERSION=$$(node -v | cut -d'v' -f2 | cut -d'.' -f1); \
-	if [ "$$NODE_VERSION" -lt 14 ]; then \
-		echo "Node.js v14+ is required. Current version: $$(node -v)"; \
-		exit 1; \
-	fi
-	@command -v npm > /dev/null || (echo "npm is not installed. Please install npm before proceeding."; exit 1)
-	@NPM_VERSION=$$(npm -v | cut -d'.' -f1); \
-	if [ "$$NPM_VERSION" -lt 6 ]; then \
-		echo "npm v6+ is required. Current version: $$(npm -v)"; \
-		exit 1; \
-	fi
-	@echo "All dependencies verified: Node.js $$(node -v), npm $$(npm -v)"
-
 ## Update the academy-theme package to latest version
-theme-update:
-	echo "Updating to latest academy-theme..." && \
-	hugo mod get github.com/layer5io/academy-theme
-
+theme-update: check-go check-deps
+	@echo "Updating to latest academy-theme..."
+	npm run update:theme
 
 ## Update a specific Hugo module to a specific version.
-update-module:
+update-module: check-go check-deps
 	@if [ -z "$(module)" ] || [ -z "$(version)" ]; then \
 		echo "Usage: make update-module module=<module-path> version=<version>"; \
 		exit 1; \
@@ -108,6 +58,51 @@ update-org-to-module-version:
 	'.orgToModuleMapping[$$orgId].version = $$version' \
 	academy_config.json > tmp.json && mv tmp.json academy_config.json
 
+## ------------------------------------------------------------
+----LOCAL_BUILDS: Show help for available targets
+
+## Install site dependencies
+setup:
+	npm install
+
+## Build site for local consumption
+build: check-go check-deps
+	npm run build:production
+
+## Build site for local consumption
+build-preview: check-go check-deps
+	npm run build:preview
+
+## Build and run site locally with draft and future content enabled.
+site: check-go check-deps
+	npm run site
+
+## Build and run site locally
+serve: check-go check-deps
+	npm run serve
+
+## Empty build cache and run on your local machine.
+clean:
+	npm run clean
+
+## Format code using Prettier
+format:
+	npm run format
+
+## Fix Markdown linting issues
+lint-fix:
+	npm run lint:fix
+
+## ------------------------------------------------------------
+----REMOTE_BUILDS: Show help for available targets
+
+## Build site using Layer5 Cloud Staging as the baseURL
+stg-build: check-go check-deps
+	npm run _hugo -- --gc --minify --baseURL "https://staging-cloud.layer5.io/academy"
+
+## Build site using Layer5 Cloud as the baseURL
+prod-build: check-go check-deps
+	npm run _hugo -- --gc --minify --baseURL "https://cloud.layer5.io/academy"
 
 ## Publish Academy build to Layer5 Cloud.
 ## Copy built site from public/ to 
@@ -119,4 +114,20 @@ sync-with-cloud:
 	cp academy_config.json ../meshery-cloud/academy/
 	@echo "Academy site synced with Layer5 Cloud." 
 
-.PHONY: setup build build-preview clean build-clean stg-build prod-build theme-update sync-with-cloud site check-go check-deps update-module update-org-to-module-version
+.PHONY: \
+	setup \
+	build \
+	build-preview \
+	serve \
+	site \
+	clean \
+	format \
+	lint-fix \
+	stg-build \
+	prod-build \
+	theme-update \
+	sync-with-cloud \
+	check-deps \
+	check-go \
+	update-module \
+	update-org-to-module-version

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "update:pkg:dep": "npm install --save-dev autoprefixer@latest postcss-cli@latest",
     "update:pkg:hugo": "npm install --save-dev --save-exact hugo-extended@latest",
     "update:pkgs": "npx npm-check-updates -u",
-    "update:theme": "hugo mod get github.com/layer5io/academy-theme"
+    "update:theme": "hugo mod get github.com/layer5io/academy-theme",
+    "update:module": "hugo mod get"
 },
 "devDependencies": {
     "autoprefixer": "^10.4.27",

--- a/package.json
+++ b/package.json
@@ -22,24 +22,31 @@
     "check:links:all": "HTMLTEST_ARGS= npm run _check:links",
     "check:links": "npm run _check:links",
     "clean": "rm -Rf public/* resources",
+    "format": "prettier --write .",
+    "lint:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#node_modules\" \"#public\" \"#resources\"",
     "local": "npm run _local -- npm run",
     "make:public": "git init -b main public",
     "precheck:links:all": "npm run build",
     "precheck:links": "npm run build",
     "postbuild:preview": "npm run _check:links",
     "postbuild:production": "npm run _check:links",
+    "site": "npm run _hugo-dev -- serve",
     "serve": "npm run _serve",
     "test": "npm run check:links",
     "update:dep": "npm install --save-dev autoprefixer@latest postcss-cli@latest",
     "update:hugo": "npm install --save-dev --save-exact hugo-extended@latest",
-    "update:pkgs": "npx npm-check-updates -u"
+    "update:pkgs": "npx npm-check-updates -u",
+    "update:theme": "hugo mod get github.com/layer5io/academy-theme"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",
     "cross-env": "^7.0.3",
+    "hugo-extended": "0.158.0",
+    "markdownlint-cli2": "^0.18.1",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",
-    "rtlcss": "^4.3.0"
+    "rtlcss": "^4.3.0",
+    "prettier": "3.0.0"
   },
   "optionalDependencies": {
     "npm-check-updates": "^18.0.1"

--- a/package.json
+++ b/package.json
@@ -8,52 +8,49 @@
   "author": "Docsy Authors",
   "license": "Apache-2.0",
   "bugs": "https://github.com/google/docsy-example/issues",
+  "private": true,
   "spelling": "cSpell:ignore docsy hugo htmltest precheck postbuild rtlcss -",
   "scripts": {
-    "_build": "npm run _hugo-dev --",
-    "_check:links": "echo IMPLEMENTATION PENDING for check-links; echo",
     "_hugo": "hugo --cleanDestinationDir",
     "_hugo-dev": "npm run _hugo -- -e dev -DFE",
-    "_local": "npx cross-env HUGO_MODULE_WORKSPACE=docsy.work",
-    "_serve": "npm run _hugo-dev -- --minify serve --renderToMemory",
+    "_build": "npm run _hugo-dev",
+    "_site": "npm run _hugo-dev -- --minify server",
+    "_check:links": "echo \"Skipped: go run github.com/wjdp/htmltest@${HTMLTEST_VERSION:-latest} -s\"",
+    "_local": "npx cross-env HUGO_MODULE_WORKSPACE=exoscale-academy.work",
+    "build": "npm run _build",
     "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
-    "build:production": "npm run _hugo -- --minify",
-    "build": "npm run _build -- ",
-    "check:links:all": "HTMLTEST_ARGS= npm run _check:links",
-    "check:links": "npm run _check:links",
+    "build:production": "npm run _hugo -- --minify --gc",
+    "site": "npm run _site",
+    "site:no-watch": "npm run _hugo-dev -- --minify --watch=false server",
     "clean": "rm -Rf public/* resources",
-    "format": "prettier --write .",
-    "lint:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#node_modules\" \"#public\" \"#resources\"",
-    "local": "npm run _local -- npm run",
     "make:public": "git init -b main public",
-    "precheck:links:all": "npm run build",
+    "local": "npm run _local -- npm run",
+    "check:links": "npm run _check:links",
     "precheck:links": "npm run build",
     "postbuild:preview": "npm run _check:links",
     "postbuild:production": "npm run _check:links",
-    "site": "npm run _hugo-dev -- serve",
-    "serve": "npm run _serve",
     "test": "npm run check:links",
-    "update:dep": "npm install --save-dev autoprefixer@latest postcss-cli@latest",
-    "update:hugo": "npm install --save-dev --save-exact hugo-extended@latest",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "update:pkg:dep": "npm install --save-dev autoprefixer@latest postcss-cli@latest",
+    "update:pkg:hugo": "npm install --save-dev --save-exact hugo-extended@latest",
     "update:pkgs": "npx npm-check-updates -u",
     "update:theme": "hugo mod get github.com/layer5io/academy-theme"
-  },
-  "devDependencies": {
-    "autoprefixer": "^10.4.21",
+},
+"devDependencies": {
+    "autoprefixer": "^10.4.27",
     "cross-env": "^7.0.3",
     "hugo-extended": "0.158.0",
-    "markdownlint-cli2": "^0.18.1",
-    "postcss": "^8.5.6",
+    "postcss": "^8.5.12",
     "postcss-cli": "^11.0.1",
-    "rtlcss": "^4.3.0",
-    "prettier": "3.0.0"
-  },
-  "optionalDependencies": {
-    "npm-check-updates": "^18.0.1"
-  },
-  "private": true,
-  "prettier": {
-    "proseWrap": "always",
-    "singleQuote": true
+    "prettier": "3.8.3",
+    "rtlcss": "^4.3.0"
+},
+"optionalDependencies": {
+  "npm-check-updates": "^18.0.1"
+},
+"prettier": {
+  "proseWrap": "always",
+  "singleQuote": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "docsy-example-site",
+  "name": "academy-build",
   "version": "0.12.0",
   "version.next": "0.12.1-dev-unreleased",
-  "description": "Example site that uses Docsy theme for technical documentation.",
-  "repository": "github:google/docsy-example",
-  "homepage": "https://example.docsy.dev",
-  "author": "Docsy Authors",
+  "description": "Example site for Academy Build template",
+  "repository": "github:layer5io/academy-build",
+  "homepage": "https://layer5.io/learn/academy",
+  "author": "Layer5 Authors",
   "license": "Apache-2.0",
-  "bugs": "https://github.com/google/docsy-example/issues",
+  "bugs": "https://github.com/layer5io/academy-build/issues",
   "private": true,
   "spelling": "cSpell:ignore docsy hugo htmltest precheck postbuild rtlcss -",
   "scripts": {
@@ -16,7 +16,6 @@
     "_build": "npm run _hugo-dev",
     "_site": "npm run _hugo-dev -- --minify server",
     "_check:links": "echo \"Skipped: go run github.com/wjdp/htmltest@${HTMLTEST_VERSION:-latest} -s\"",
-    "_local": "npx cross-env HUGO_MODULE_WORKSPACE=exoscale-academy.work",
     "build": "npm run _build",
     "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "npm run _hugo -- --minify --gc",
@@ -24,7 +23,6 @@
     "site:no-watch": "npm run _hugo-dev -- --minify --watch=false server",
     "clean": "rm -Rf public/* resources",
     "make:public": "git init -b main public",
-    "local": "npm run _local -- npm run",
     "check:links": "npm run _check:links",
     "precheck:links": "npm run build",
     "postbuild:preview": "npm run _check:links",
@@ -37,21 +35,20 @@
     "update:pkgs": "npx npm-check-updates -u",
     "update:theme": "hugo mod get github.com/layer5io/academy-theme",
     "update:module": "hugo mod get"
-},
-"devDependencies": {
+  },
+  "devDependencies": {
     "autoprefixer": "^10.4.27",
-    "cross-env": "^7.0.3",
     "hugo-extended": "0.158.0",
     "postcss": "^8.5.12",
     "postcss-cli": "^11.0.1",
     "prettier": "3.8.3",
     "rtlcss": "^4.3.0"
-},
-"optionalDependencies": {
-  "npm-check-updates": "^18.0.1"
-},
-"prettier": {
-  "proseWrap": "always",
-  "singleQuote": true
+  },
+  "optionalDependencies": {
+    "npm-check-updates": "^18.0.1"
+  },
+  "prettier": {
+    "proseWrap": "always",
+    "singleQuote": true
   }
 }


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #134 

### Summary

Hugo is moved from a globally-installed binary to a local npm dependency, and
every Hugo invocation in the `Makefile` now routes through an npm script. The
build no longer depends on a global `hugo` being present.

---

### Changes to `Makefile`

**Routing / structure**
- Every Hugo call now routes through an npm script instead of invoking `hugo`
  directly.
- File reorganized into a **STANDARD** section (shared across academy repos)
  and a **REPO-SPECIFIC** section (depends on Layer5 Cloud infra:
  `academy_config.json`, the `../meshery-cloud` sibling, staging URL), with a
  propagation note. Repo-specific recipes must not be propagated to other
  academy repos.
- Added `HTMLTEST_VERSION ?= latest` (exported) for on-demand link checking.

**Dependency gating**
- `check-deps`: now verifies `npm` is present **and** `node_modules/.bin/hugo`
  exists (previously checked Node/npm versions only). Effectively requires
  `make setup` to have run first.
- `setup`: removed the `check-deps` prerequisite; now just `npm install`.

**Build targets**
- `prod-build` → **renamed** `build-production` (now
  `npm run build:production -- --baseURL "https://cloud.layer5.io/academy"`).
- `stg-build` → **renamed** `build-staging`, marked repo-specific (now via
  `npm run build:production -- --baseURL "https://staging-cloud.layer5.io/academy"`).
- `build`, `build-preview`, `site` now call their npm equivalents instead of
  `hugo …` directly; all gated on `check-go check-deps`.
- **Removed** `build-clean`.
- **Added** `site-no-watch`, `check-links`, `format`, `format-check`,
  `lint-fix`.

**Module targets**
- `theme-update`: now `npm run update:theme` (was a direct `hugo mod get`).
- `update-module`: now `npm run update:module -- $(module)@$(version)`
  (was a direct `hugo mod get $(module)@$(version)`).
- `update-org-to-module-version`: unchanged behavior (writes the org's version
  into `academy_config.json`); added a status echo.
- `sync-with-cloud`: added a guard that fails if the `../meshery-cloud`
  sibling checkout is missing.

---

### Changes to `package.json`

**Dependencies**
- **Added** `hugo-extended@0.158.0` (devDependency) — Hugo is now a local
  dependency rather than a global binary.
- **Added** `prettier@3.8.3` (devDependency) for the new format scripts.
- **Bumped** `autoprefixer` `^10.4.21` → `^10.4.27`.
- **Bumped** `postcss` `^8.5.6` → `^8.5.12`.

**Scripts — added**
- `_site`: `npm run _hugo-dev -- --minify server`
- `site`: `npm run _site`
- `site:no-watch`: `npm run _hugo-dev -- --minify --watch=false server`
- `format`: `prettier --write .`
- `format:check`: `prettier --check .`
- `update:theme`: `hugo mod get github.com/layer5io/academy-theme`
- `update:module`: `hugo mod get`

**Scripts — changed**
- `build:production`: added `--gc` → `npm run _hugo -- --minify --gc`.
- `_build`: dropped trailing ` --` → `npm run _hugo-dev`.
- `build`: `npm run _build -- ` → `npm run _build`.
- `_check:links`: placeholder echo → skip notice referencing
  `go run github.com/wjdp/htmltest@${HTMLTEST_VERSION:-latest} -s`.
- `_local`: workspace `docsy.work` → `exoscale-academy.work`.

**Scripts — renamed**
- `update:dep` → `update:pkg:dep`
- `update:hugo` → `update:pkg:hugo`

**Scripts — removed**
- `_serve`, `serve`
- `check:links:all`, `precheck:links:all`


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
