### PR TITLE
[chore]: align workflow with makefile standardization

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -26,19 +26,30 @@ on:
 
 jobs:
   build-artifacts:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: 'master'
 
-      - name: Setup Hugo (Extended)
-        uses: peaceiris/actions-hugo@v3
+      # Required: academy-theme is a Hugo module, so the build needs Go.
+      # 'make build-production' and 'make update-module' run check-go and fail fast without it.
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
-          hugo-version: '0.158.0'
-          extended: true
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: make setup
 
       - name: Conditionally update Hugo module based on orgId
         if: ${{ github.event.inputs.orgId != '' }}
@@ -53,12 +64,12 @@ jobs:
           fi
 
           echo "✅ Found module for orgId '$ORG_ID': $MODULE"
-          
+
           # Set environment variables for later steps
           echo "ACADEMY_NAME=${MODULE##*/}" >> $GITHUB_ENV
           echo "NOTES=Updated from academy-build workflow" >> $GITHUB_ENV
-          
-          make update-module  module="$MODULE" version="$VERSION"
+
+          make update-module module="$MODULE" version="$VERSION"
           make update-org-to-module-version orgId="$ORG_ID" version="$VERSION"
 
       - name: Set default environment variables
@@ -73,11 +84,8 @@ jobs:
           echo "ACADEMY_NAME=${ACADEMY_NAME:-Layer5 Academy}" >> $GITHUB_ENV
           echo "NOTES=${NOTES:-Build from academy-build workflow}" >> $GITHUB_ENV
 
-      - name: Install dependencies
-        run: make setup
-
       - name: Build Academy
-        run: make prod-build
+        run: make build-production
 
       - name: Pull changes from self master
         run: git pull origin master
@@ -88,11 +96,11 @@ jobs:
           commit_options: '--signoff'
           branch: master
           commit_user_name: l5io
-          commit_user_email: l5io@layer5.io  
+          commit_user_email: l5io@layer5.io
           commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
 
       - name: Checkout meshery-cloud repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: layer5io/meshery-cloud
           token: ${{ secrets.GH_ACCESS_TOKEN }}
@@ -104,25 +112,12 @@ jobs:
           rm -rf meshery-cloud/academy
           mkdir -p meshery-cloud/academy
           rsync -av --delete public/ meshery-cloud/academy/
-          cp  academy_config.json meshery-cloud/academy/
-
-      # - name: Commit & push academy to meshery-cloud
-      #   uses: stefanzweifel/git-auto-commit-action@v5
-      #   with:
-      #     commit_message: "[Academy] Content update for orgId: ${{ github.event.inputs.orgId || 'manual' }}"
-      #     commit_options: '--signoff'
-      #     repository: meshery-cloud
-      #     branch: academy/content-update
-      #     file_pattern: academy
-      #     commit_user_name: l5io
-      #     commit_user_email: l5io@layer5.io
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          cp academy_config.json meshery-cloud/academy/
 
       - name: Create PR in meshery-cloud for release-drafter integration
         if: github.event.inputs.version != ''
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           path: meshery-cloud


### PR DESCRIPTION
**Notes for Reviewers**
- This PR should be merged after #133 PR has been merged
- **`make prod-build` → `make build-production`** — blocking. The standardized Makefile renamed the target; the "Build Academy" step would fail with `No rule to make target 'prod-build'`. The composed Hugo command is unchanged (`hugo --cleanDestinationDir --minify --gc --baseURL "https://cloud.layer5.io/academy"`).
- **`update-module` now routes through `npm run update:module`** instead of calling `hugo mod get` directly. `node_modules/.bin` is only on `PATH` inside `npm run`, so this lets the module update use the same `hugo-extended` version as every other build. Adds `"update:module": "hugo mod get"` to `package.json` and a `check-deps` prerequisite to the target.
- **Removed `peaceiris/actions-hugo`** — redundant once `update-module` goes through npm. `make setup` installs `hugo-extended` into `node_modules/.bin`, and every Hugo call now reaches it via `npm run`. Dropping it also removes a second place the Hugo version was pinned.
- **Added `Setup Go`** — required. `make build-production` and `make update-module` both run `check-go` and hard-fail without it, and Hugo needs Go to resolve the theme module.
- **Added `Setup Node`** (20 + npm cache).
- **Moved `Install dependencies` (`make setup`) above the module-update step** — required, since `update-module` now depends on `check-deps`, which asserts `node_modules/.bin/hugo` exists.
- **Removed the commented-out `git-auto-commit-action` block** — dead code.
- `checkout@v5` → `@v6`; `create-pull-request@v6` → `@v7`; `ubuntu-22.04` → `ubuntu-latest`.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
