### PR TITLE
[chore]: remove package-lock.json cache from workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -40,13 +40,11 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-          cache: true
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Install dependencies
         run: make setup


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #139 

There was a workflow failure due to `Error: Dependencies lock file is not found in /home/runner/work/academy-build/academy-build. Supported file patterns: package-lock.json,npm-shrinkwrap.json,yarn.lock`. This was being caused by the usage of of npm: cache when there's no package-lock.json files within the repo

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
