### PR TITLE
Fix tcslabs-academy v2 Go module path in academy build

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -63,8 +63,11 @@ jobs:
 
           echo "✅ Found module for orgId '$ORG_ID': $MODULE"
 
-          # Set environment variables for later steps
-          echo "ACADEMY_NAME=${MODULE##*/}" >> $GITHUB_ENV
+          # Set environment variables for later steps.
+          # Strip an optional Go major-version suffix (e.g. /v2) so the academy
+          # name is the repo name (tcslabs-academy), not the version segment.
+          MODULE_PATH="${MODULE%/v[0-9]*}"
+          echo "ACADEMY_NAME=${MODULE_PATH##*/}" >> $GITHUB_ENV
           echo "NOTES=Updated from academy-build workflow" >> $GITHUB_ENV
 
           make update-module module="$MODULE" version="$VERSION"

--- a/academy_config.json
+++ b/academy_config.json
@@ -21,8 +21,8 @@
       "version": "v0.4.29"
     },
     "deea6061-b6be-49a9-ad1c-f1a5c32e1fa9": {
-      "module": "github.com/meshery-extensions/tcslabs-academy",
-      "version": "v0.0.1"
+      "module": "github.com/meshery-extensions/tcslabs-academy/v2",
+      "version": "v2.1.9"
     }
   }
 }


### PR DESCRIPTION
## Symptom
The `Build and push to remote` workflow ([run 29290570119](https://github.com/layer5io/academy-build/actions/runs/29290570119/job/86953011315)) failed at **Conditionally update Hugo module based on orgId**:

```
go: github.com/meshery-extensions/tcslabs-academy@v2.1.8: invalid version:
go.mod has post-v2 module path "github.com/meshery-extensions/tcslabs-academy/v2" at revision v2.1.8
```

The build never started.

## Root cause
The workflow resolves the module with `hugo mod get <module>@<version>`, reading `<module>` verbatim from `academy_config.json`. `tcslabs-academy` advanced to **major version 2** - its `go.mod` declares `github.com/meshery-extensions/tcslabs-academy/v2` and it carries `v2.x` tags. Under Go's Semantic Import Versioning, consumers of a v2+ module **must** use the `/v2` suffix in the import path. The config still mapped the org to the un-suffixed path, so Go rejected the `v2.x` version.

## Fix
- **academy_config.json**: use the correct module path `github.com/meshery-extensions/tcslabs-academy/v2`, and point at the released `v2.1.9` (the stale `v0.0.1` was also an invalid pairing with a v2 module).
- **build-and-release.yml**: `ACADEMY_NAME` was `${MODULE##*/}` (last path segment); with the `/v2` suffix that silently becomes `v2`. Strip an optional Go major-version suffix (`/vN`) first so it stays `tcslabs-academy`. Generic for any future v2+/v3+ academy.

## Verification
- Reproduced the exact `invalid version` failure with the old path; confirmed the corrected path resolves to `github.com/meshery-extensions/tcslabs-academy/v2 v2.1.9` via the Go proxy using the runner's `go 1.26.4`.
- Tested the `ACADEMY_NAME` expansion against every module in the config plus a hypothetical `/v3`.
- Built the `tcslabs-academy` site locally (443 pages, clean).

## Watch for
Other academies in the config are still v0/v1 and unaffected. When any of them tags a `v2.0.0`, its mapping must gain the matching `/vN` suffix or it will hit the identical failure; the `ACADEMY_NAME` derivation already handles that side generically.