### PR TITLE
[Automated] Update academy-theme to v0.4.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,12 @@ replace github.com/FortAwesome/Font-Awesome v4.7.0+incompatible => github.com/Fo
 
 require (
 	github.com/FortAwesome/Font-Awesome v4.7.0+incompatible // indirect
-	github.com/layer5io/academy-theme v0.4.17 // indirect
+	github.com/layer5io/academy-theme v0.4.18 // indirect
 	github.com/layer5io/digitalocean-academy v0.1.20 // indirect
 	github.com/layer5io/exoscale-academy v0.6.39 // indirect
 	github.com/layer5io/layer5-academy v0.8.22 // indirect
 	github.com/meshery-extensions/meshery-academy v0.4.29 // indirect
+	github.com/meshery-extensions/tcslabs-academy v1.2.0 // indirect
 	github.com/meshery-extensions/tcslabs-academy/v2 v2.2.0 // indirect
 	github.com/twbs/bootstrap v5.3.8+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/layer5io/academy-theme v0.4.16 h1:nrwEIv8mji6sfq7cazyJVhGEoeisqu5RdQ0
 github.com/layer5io/academy-theme v0.4.16/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
 github.com/layer5io/academy-theme v0.4.17 h1:rnTuWwEIyYqtFyqiDz+GZOSTz/Wpud8256+QtH0HYXM=
 github.com/layer5io/academy-theme v0.4.17/go.mod h1:Dv72UWsREOvX4Zg4mJjrpoyDxdgxxpiDotxqYBXMjXo=
+github.com/layer5io/academy-theme v0.4.18 h1:czJxqyLtNu2qUkKeJ+ez7uAb4riu9s/4vNAvcsH36mM=
+github.com/layer5io/academy-theme v0.4.18/go.mod h1:oe18PzjKqTv8WptTZx5qbRljga9VUlDpyA2tZdLxWsI=
 github.com/layer5io/digitalocean-academy v0.0.0-20250811164829-9c9fe0d0fb30 h1:uOYEZhHFszNjb0ceanoSk118T+6KAFcTopZGYNSVLeQ=
 github.com/layer5io/digitalocean-academy v0.0.0-20250811164829-9c9fe0d0fb30/go.mod h1:HwJAxS+mg1K33NKaDIngdVhya6+GPAraeTyi6g+4268=
 github.com/layer5io/digitalocean-academy v0.1.1 h1:cYIV8WZGCUHxrEg1NtXtqIhvQuWVbvlGmzl6knsS6So=
@@ -296,6 +298,8 @@ github.com/meshery-extensions/meshery-academy v0.4.28 h1:4g32to2qutRkvFURLFyyBa8
 github.com/meshery-extensions/meshery-academy v0.4.28/go.mod h1:t89mYG+7JKg+i2b3I2rpJ0UiPiMzc2I4D4TtZUWYkpY=
 github.com/meshery-extensions/meshery-academy v0.4.29 h1:DyhDsV5Utlq7BRSgmh//amXiSC50DFjQn6NGHd96HjQ=
 github.com/meshery-extensions/meshery-academy v0.4.29/go.mod h1:aqgXfRF7xL7/e8thKnSK5W+YJCnJzkqMF2GXooiMYA4=
+github.com/meshery-extensions/tcslabs-academy v1.2.0 h1:8ulGDKONx4VO/a4kvfNJ4buHLePKqSOengGglDdj+PY=
+github.com/meshery-extensions/tcslabs-academy v1.2.0/go.mod h1:IwietVQaLpYbDsoUiHLAOOYW97U2rhpzc9IQRQRsXnY=
 github.com/meshery-extensions/tcslabs-academy/v2 v2.1.10 h1:d2xeXeQW2DrE3LYOEG95QcZGQCPFthXDHpaUidQiaH8=
 github.com/meshery-extensions/tcslabs-academy/v2 v2.1.10/go.mod h1:CLxpPjGeoN9FSpMP4lEgzDXSstLN3Ip/LilBLKTbF3o=
 github.com/meshery-extensions/tcslabs-academy/v2 v2.1.11 h1:6dWfQpC/GpjUA+06imhYTwNsgOoRFP7TXDl7Cgqxbi4=


### PR DESCRIPTION
This PR updates the academy-theme dependency to the latest release version v0.4.18.

Changes:
- Updated go.mod
- Regenerated go.sum

Auto-generated based upon release of a new version of layer5io/academy-theme.