### PR TITLE
[Academy] Use tcslabs-academy /v2 module path for org deea6061

### DIFF
--- a/academy_config.json
+++ b/academy_config.json
@@ -21,7 +21,7 @@
       "version": "v0.4.29"
     },
     "deea6061-b6be-49a9-ad1c-f1a5c32e1fa9": {
-      "module": "github.com/meshery-extensions/tcslabs-academy",
+      "module": "github.com/meshery-extensions/tcslabs-academy/v2",
       "version": "v2.2.2"
     }
   }

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -286,7 +286,7 @@ module:
           target: static/3e2f9c82-1a4c-4781-adf9-99ec22cd994e
           disableWatch: false
     
-    - path: github.com/meshery-extensions/tcslabs-academy
+    - path: github.com/meshery-extensions/tcslabs-academy/v2
       disable: false
 
       mounts:


### PR DESCRIPTION
**Notes for Reviewers**

The TCS Labs org (`deea6061-b6be-49a9-ad1c-f1a5c32e1fa9`) is published at `v2.2.2`, which is a **v2 Go module** and must be referenced with the `/v2` major-version suffix.

Both `hugo.yaml` and `academy_config.json` referenced the bare path `github.com/meshery-extensions/tcslabs-academy`, which resolves to the old **v1.2.0** line. As a result, production builds mounted stale v1 content whose content IDs are not registered in the Academy registry, and `make build-production` failed with 13 `Invalid Content ID` errors (`validationMode: error`).

**Change**
- `hugo.yaml` — module import path → `github.com/meshery-extensions/tcslabs-academy/v2`
- `academy_config.json` — org mapping module → `github.com/meshery-extensions/tcslabs-academy/v2` (version already `v2.2.2`; this also lets the release workflow's `make update-module` resolve the version correctly, since it strips the `/v2` suffix only for the derived academy name)

`go.mod` already declares `github.com/meshery-extensions/tcslabs-academy/v2 v2.2.2`, so no module version bump is needed.

**Verification**
`make build-production` (Hugo `--minify --gc`, drafts off) now completes successfully. The v2.2.2 published items carry registered IDs, and the three unreleased learning paths (`foundations-…`, `ai-engineering-…`, `ai-assisted-…`) are marked `draft: true` and are excluded from the production build as expected.

This PR fixes #

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
