### PR TITLE
Derive Go module version suffix in build workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -55,55 +55,19 @@ jobs:
           ORG_ID="${{ github.event.inputs.orgId }}"
           VERSION="${{ github.event.inputs.version || 'latest' }}"
 
-          # academy_config.json stores the BARE module path (no /vN suffix). The
-          # Semantic Import Versioning (SIV) suffix is derived here from the
-          # target version, so no academy needs to be hand-tagged with /v2.
+          # academy_config.json stores the BARE module path; 'make update-academy'
+          # derives the Go /vN suffix from the version and syncs hugo.yaml + go.mod.
+          # Here we only surface the academy name (repo name) for later steps.
           BASE=$(jq -r --arg orgId "$ORG_ID" '.orgToModuleMapping[$orgId].module' academy_config.json)
-
           if [ "$BASE" = "null" ] || [ -z "$BASE" ]; then
             echo "❌ Module not found for orgId: $ORG_ID"
             exit 1
           fi
-          # Defensively strip a legacy /vN suffix so either config form works.
           BASE="${BASE%/v[0-9]*}"
-
-          # Resolve "latest" to a concrete tag. Go/Hugo module resolution never
-          # crosses a major-version boundary on a bare path, so we must learn the
-          # real major before we can construct the import path.
-          if [ "$VERSION" = "latest" ] || [ -z "$VERSION" ]; then
-            VERSION=$(git ls-remote --tags --refs "https://${BASE}.git" \
-              | sed -E 's#.*refs/tags/##' \
-              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-              | sort -V | tail -n1)
-            if [ -z "$VERSION" ]; then
-              echo "❌ Could not resolve a latest semver tag for $BASE"
-              exit 1
-            fi
-            echo "Resolved latest -> $VERSION"
-          fi
-
-          # Derive the SIV-correct import path:
-          #   major >= 2 -> <base>/vN  (required by Go)
-          #   major 0|1  -> <base>     (no suffix)
-          MAJOR="${VERSION#v}"; MAJOR="${MAJOR%%.*}"
-          if [ "${MAJOR:-0}" -ge 2 ] 2>/dev/null; then
-            MODULE="${BASE}/v${MAJOR}"
-          else
-            MODULE="$BASE"
-          fi
-          echo "✅ orgId '$ORG_ID' -> import '$MODULE' @ '$VERSION'"
-
-          # Set environment variables for later steps (academy name = repo name).
           echo "ACADEMY_NAME=${BASE##*/}" >> $GITHUB_ENV
           echo "NOTES=Updated from academy-build workflow" >> $GITHUB_ENV
 
-          # Keep hugo.yaml's mount import path in sync with the derived path.
-          # Match this module's "- path: <base>[/vN]" line and rewrite it.
-          ESC_BASE=$(printf '%s' "$BASE" | sed -e 's/[.[\*^$/]/\\&/g')
-          sed -i -E "s|^([[:space:]]*- path: )${ESC_BASE}(/v[0-9]+)?[[:space:]]*\$|\1${MODULE}|" hugo.yaml
-
-          make update-module module="$MODULE" version="$VERSION"
-          make update-org-to-module-version orgId="$ORG_ID" version="$VERSION"
+          make update-academy orgId="$ORG_ID" version="$VERSION"
 
       - name: Set default environment variables
         if: ${{ github.event.inputs.orgId == '' }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -54,21 +54,53 @@ jobs:
         run: |
           ORG_ID="${{ github.event.inputs.orgId }}"
           VERSION="${{ github.event.inputs.version || 'latest' }}"
-          MODULE=$(jq -r --arg orgId "$ORG_ID" '.orgToModuleMapping[$orgId].module' academy_config.json)
 
-          if [ "$MODULE" = "null" ] || [ -z "$MODULE" ]; then
+          # academy_config.json stores the BARE module path (no /vN suffix). The
+          # Semantic Import Versioning (SIV) suffix is derived here from the
+          # target version, so no academy needs to be hand-tagged with /v2.
+          BASE=$(jq -r --arg orgId "$ORG_ID" '.orgToModuleMapping[$orgId].module' academy_config.json)
+
+          if [ "$BASE" = "null" ] || [ -z "$BASE" ]; then
             echo "❌ Module not found for orgId: $ORG_ID"
             exit 1
           fi
+          # Defensively strip a legacy /vN suffix so either config form works.
+          BASE="${BASE%/v[0-9]*}"
 
-          echo "✅ Found module for orgId '$ORG_ID': $MODULE"
+          # Resolve "latest" to a concrete tag. Go/Hugo module resolution never
+          # crosses a major-version boundary on a bare path, so we must learn the
+          # real major before we can construct the import path.
+          if [ "$VERSION" = "latest" ] || [ -z "$VERSION" ]; then
+            VERSION=$(git ls-remote --tags --refs "https://${BASE}.git" \
+              | sed -E 's#.*refs/tags/##' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -V | tail -n1)
+            if [ -z "$VERSION" ]; then
+              echo "❌ Could not resolve a latest semver tag for $BASE"
+              exit 1
+            fi
+            echo "Resolved latest -> $VERSION"
+          fi
 
-          # Set environment variables for later steps.
-          # Strip an optional Go major-version suffix (e.g. /v2) so the academy
-          # name is the repo name (tcslabs-academy), not the version segment.
-          MODULE_PATH="${MODULE%/v[0-9]*}"
-          echo "ACADEMY_NAME=${MODULE_PATH##*/}" >> $GITHUB_ENV
+          # Derive the SIV-correct import path:
+          #   major >= 2 -> <base>/vN  (required by Go)
+          #   major 0|1  -> <base>     (no suffix)
+          MAJOR="${VERSION#v}"; MAJOR="${MAJOR%%.*}"
+          if [ "${MAJOR:-0}" -ge 2 ] 2>/dev/null; then
+            MODULE="${BASE}/v${MAJOR}"
+          else
+            MODULE="$BASE"
+          fi
+          echo "✅ orgId '$ORG_ID' -> import '$MODULE' @ '$VERSION'"
+
+          # Set environment variables for later steps (academy name = repo name).
+          echo "ACADEMY_NAME=${BASE##*/}" >> $GITHUB_ENV
           echo "NOTES=Updated from academy-build workflow" >> $GITHUB_ENV
+
+          # Keep hugo.yaml's mount import path in sync with the derived path.
+          # Match this module's "- path: <base>[/vN]" line and rewrite it.
+          ESC_BASE=$(printf '%s' "$BASE" | sed -e 's/[.[\*^$/]/\\&/g')
+          sed -i -E "s|^([[:space:]]*- path: )${ESC_BASE}(/v[0-9]+)?[[:space:]]*\$|\1${MODULE}|" hugo.yaml
 
           make update-module module="$MODULE" version="$VERSION"
           make update-org-to-module-version orgId="$ORG_ID" version="$VERSION"

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,41 @@ update-org-to-module-version:
 	'.orgToModuleMapping[$$orgId].version = $$version' \
 	academy_config.json > tmp.json && mv tmp.json academy_config.json
 
+## [repo-specific] Update an org's academy to a module version end-to-end.
+## Reads the BARE module path from academy_config.json, derives the Go Semantic
+## Import Versioning (/vN) suffix from the target version, syncs hugo.yaml, and
+## updates go.mod + academy_config.json. version defaults to 'latest'.
+update-academy: check-go check-deps
+	@if [ -z "$(orgId)" ]; then \
+		echo "Usage: make update-academy orgId=<org-id> [version=<version>]"; \
+		exit 1; \
+	fi; \
+	ORG_ID="$(orgId)"; \
+	VERSION="$(version)"; \
+	if [ -z "$$VERSION" ]; then VERSION="latest"; fi; \
+	BASE=$$(jq -r --arg orgId "$$ORG_ID" '.orgToModuleMapping[$$orgId].module' academy_config.json); \
+	if [ "$$BASE" = "null" ] || [ -z "$$BASE" ]; then \
+		echo "❌ Module not found for orgId: $$ORG_ID"; exit 1; \
+	fi; \
+	BASE="$${BASE%/v[0-9]*}"; \
+	if [ "$$VERSION" = "latest" ]; then \
+		VERSION=$$(git ls-remote --tags --refs "https://$$BASE.git" \
+			| sed -E 's#.*refs/tags/##' \
+			| grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$$' \
+			| sort -V | tail -n1); \
+		if [ -z "$$VERSION" ]; then \
+			echo "❌ Could not resolve a latest semver tag for $$BASE"; exit 1; \
+		fi; \
+		echo "Resolved latest -> $$VERSION"; \
+	fi; \
+	MAJOR="$${VERSION#v}"; MAJOR="$${MAJOR%%.*}"; \
+	if [ "$${MAJOR:-0}" -ge 2 ] 2>/dev/null; then MODULE="$$BASE/v$$MAJOR"; else MODULE="$$BASE"; fi; \
+	echo "✅ orgId '$$ORG_ID' -> import '$$MODULE' @ '$$VERSION'"; \
+	ESC_BASE=$$(printf '%s' "$$BASE" | sed -e 's/[.[\*^$$/]/\\&/g'); \
+	sed -i -E "s|^([[:space:]]*- path: )$$ESC_BASE(/v[0-9]+)?[[:space:]]*\$$|\1$$MODULE|" hugo.yaml; \
+	$(MAKE) update-module module="$$MODULE" version="$$VERSION"; \
+	$(MAKE) update-org-to-module-version orgId="$$ORG_ID" version="$$VERSION"
+
 ## [repo-specific] Publish the built site to the Layer5 Cloud (../meshery-cloud/academy).
 sync-with-cloud:
 	@test -d ../meshery-cloud || { echo "Error: ../meshery-cloud sibling checkout not found."; exit 1; }
@@ -155,4 +190,5 @@ sync-with-cloud:
 	build-staging \
 	update-module \
 	update-org-to-module-version \
+	update-academy \
 	sync-with-cloud

--- a/academy_config.json
+++ b/academy_config.json
@@ -21,7 +21,7 @@
       "version": "v0.4.29"
     },
     "deea6061-b6be-49a9-ad1c-f1a5c32e1fa9": {
-      "module": "github.com/meshery-extensions/tcslabs-academy/v2",
+      "module": "github.com/meshery-extensions/tcslabs-academy",
       "version": "v2.2.2"
     }
   }


### PR DESCRIPTION
Store the bare module path in `academy_config.json` and derive the Go Semantic Import Versioning `/vN` suffix from the target version at build time, syncing it into `hugo.yaml` and `go.mod`.

Academies no longer need to be hand-tagged with `/v2`, so workflow updates stay uniform across orgs.